### PR TITLE
Store enum values as strings

### DIFF
--- a/lib/mongoid/enum.rb
+++ b/lib/mongoid/enum.rb
@@ -8,6 +8,7 @@ module Mongoid
     module ClassMethods
 
       def enum(name, values, options = {})
+        values = values.map(&:to_s)
         field_name = :"#{Mongoid::Enum.configuration.field_name_prefix}#{name}"
         options = default_options(values).merge(options)
 
@@ -37,16 +38,16 @@ module Mongoid
       end
 
       def create_field(field_name, options)
-        type = options[:multiple] && Array || Symbol
+        type = options[:multiple] && Array || String
         field field_name, :type => type, :default => options[:default]
       end
 
       def create_validations(field_name, values, options)
         if options[:multiple] && options[:validate]
-          validates field_name, :'mongoid/enum/validators/multiple' => { :in => values.map(&:to_sym), :allow_nil => !options[:required] }
+          validates field_name, :'mongoid/enum/validators/multiple' => { :in => values, :allow_nil => !options[:required] }
         #FIXME: Shouldn't this be `elsif options[:validate]` ???
         elsif validate
-          validates field_name, :inclusion => {:in => values.map(&:to_sym)}, :allow_nil => !options[:required]
+          validates field_name, :inclusion => {:in => values}, :allow_nil => !options[:required]
         end
       end
 
@@ -71,23 +72,23 @@ module Mongoid
       end
 
       def define_array_field_accessor(name, field_name)
-        class_eval "def #{name}=(vals) self.write_attribute(:#{field_name}, Array(vals).compact.map(&:to_sym)) end"
+        class_eval "def #{name}=(vals) self.write_attribute(:#{field_name}, Array(vals).compact.map(&:to_s)) end"
         class_eval "def #{name}() self.read_attribute(:#{field_name}) end"
       end
 
       def define_string_field_accessor(name, field_name)
-        class_eval "def #{name}=(val) self.write_attribute(:#{field_name}, val && val.to_sym || nil) end"
+        class_eval "def #{name}=(val) self.write_attribute(:#{field_name}, val && val.to_s || nil) end"
         class_eval "def #{name}() self.read_attribute(:#{field_name}) end"
       end
 
       def define_array_accessor(field_name, value)
-        class_eval "def #{value}?() self.#{field_name}.include?(:#{value}) end"
-        class_eval "def #{value}!() update_attributes! :#{field_name} => (self.#{field_name} || []) + [:#{value}] end"
+        class_eval "def #{value}?() self.#{field_name}.include?('#{value}') end"
+        class_eval "def #{value}!() update_attributes! :#{field_name} => (self.#{field_name} || []) + ['#{value}'] end"
       end
 
       def define_string_accessor(field_name, value)
-        class_eval "def #{value}?() self.#{field_name} == :#{value} end"
-        class_eval "def #{value}!() update_attributes! :#{field_name} => :#{value} end"
+        class_eval "def #{value}?() self.#{field_name} == '#{value}' end"
+        class_eval "def #{value}!() update_attributes! :#{field_name} => '#{value}' end"
       end
     end
   end

--- a/spec/mongoid/enum_spec.rb
+++ b/spec/mongoid/enum_spec.rb
@@ -5,9 +5,9 @@ class User
   include Mongoid::Document
   include Mongoid::Enum
 
-  enum :status, [:awaiting_approval, :approved, :banned]
-  enum :roles, [:author, :editor, :admin], :multiple => true, :default => [], :required => false
-  enum :scopeless, [:missing], scope: false
+  enum :status, ['awaiting_approval', 'approved', 'banned']
+  enum :roles, ['author', 'editor', 'admin'], :multiple => true, :default => [], :required => false
+  enum :scopeless, ['missing'], scope: false
 end
 
 describe Mongoid::Enum do
@@ -15,7 +15,7 @@ describe Mongoid::Enum do
   let(:instance) { User.new }
   let(:alias_name) { :status }
   let(:field_name) { :"_#{alias_name}" }
-  let(:values) { [:awaiting_approval, :approved, :banned] }
+  let(:values) { ['awaiting_approval', 'approved', 'banned'] }
   let(:multiple_field_name) { :"_roles" }
 
   describe "field" do
@@ -59,7 +59,7 @@ describe Mongoid::Enum do
 
       context "when not multiple" do
         it "is a symbol" do
-          expect(klass).to have_field(field_name).of_type(Symbol)
+          expect(klass).to have_field(field_name).of_type(String)
         end
 
         it "validates inclusion in values" do
@@ -96,12 +96,12 @@ describe Mongoid::Enum do
       describe "setter" do
         it "accepts strings" do
           instance.status = 'banned'
-          expect(instance.status).to eq :banned
+          expect(instance.status).to eq 'banned'
         end
 
         it "accepts symbols" do
           instance.status = :banned
-          expect(instance.status).to eq :banned
+          expect(instance.status).to eq 'banned'
         end
       end
 
@@ -109,7 +109,7 @@ describe Mongoid::Enum do
         it "sets the value" do
           instance.save
           instance.banned!
-          expect(instance.status).to eq :banned
+          expect(instance.status).to eq 'banned'
         end
       end
 
@@ -135,12 +135,12 @@ describe Mongoid::Enum do
       describe "setter" do
         it "accepts strings" do
           instance.roles = "author"
-          expect(instance.roles).to eq [:author]
+          expect(instance.roles).to eq ['author']
         end
 
         it "accepts symbols" do
           instance.roles = :author
-          expect(instance.roles).to eq [:author]
+          expect(instance.roles).to eq ['author']
         end
 
         it "accepts arrays of strings" do
@@ -148,14 +148,14 @@ describe Mongoid::Enum do
           instance.save
           puts instance.errors.full_messages
           instance.reload
-          expect(instance.roles).to include(:author)
-          expect(instance.roles).to include(:editor)
+          expect(instance.roles).to include('author')
+          expect(instance.roles).to include('editor')
         end
 
         it "accepts arrays of symbols"  do
           instance.roles = [:author, :editor]
-          expect(instance.roles).to include(:author)
-          expect(instance.roles).to include(:editor)
+          expect(instance.roles).to include('author')
+          expect(instance.roles).to include('editor')
         end
       end
 
@@ -165,7 +165,7 @@ describe Mongoid::Enum do
             instance.roles = nil
             instance.save
             instance.author!
-            expect(instance.roles).to eq [:author]
+            expect(instance.roles).to eq ['author']
           end
         end
 
@@ -174,7 +174,7 @@ describe Mongoid::Enum do
             instance.save
             instance.author!
             instance.editor!
-            expect(instance.roles).to eq [:author, :editor]
+            expect(instance.roles).to eq ['author', 'editor']
           end
         end
       end


### PR DESCRIPTION
BSON symbols are deprecated.